### PR TITLE
Allow sims to use width specified in markup

### DIFF
--- a/src/scripts/modules/media/body/content-baked.less
+++ b/src/scripts/modules/media/body/content-baked.less
@@ -54,7 +54,6 @@ ul, ol {
 iframe {
   display: block;
   margin: 3rem auto;
-  width: 100%;
 }
 
 .centered-text {


### PR DESCRIPTION
Width of 100% was overriding the width in the HTML. Removing it allows the sims to display correctly.