### PR TITLE
Stop throwing an error when collection is empty

### DIFF
--- a/src/scripts/models/content.coffee
+++ b/src/scripts/models/content.coffee
@@ -50,7 +50,9 @@ define (require) ->
     defaultPage: ->
       result = 1
       if @isBook()
-        result += 1 while @getPage(result).get('title').match(/Preface/)
+        resultPage = @getPage(result)
+        if (resultPage != '')
+          result += 1 while resultPage.get('title').match(/Preface/)
       return result
 
     parse: (response, options = {}) ->

--- a/src/scripts/models/contents/collection.coffee
+++ b/src/scripts/models/contents/collection.coffee
@@ -36,9 +36,11 @@ define (require) ->
 
     _getPageNum: (num) ->
       pages = @allPages()
+      return '' if (pages.length == 0)
       return pages[0] if (num <= 1)
       return pages[pages.length - 1] if (num > pages.length)
       return pages[num - 1]
+      
 
     cachedPages: undefined
 


### PR DESCRIPTION
Check the length of the pages array and return an empty string for empty contents to prevent an error.