### PR TITLE
fixed line break before math elements in safari browser

### DIFF
--- a/src/scripts/modules/media/body/content-baked.less
+++ b/src/scripts/modules/media/body/content-baked.less
@@ -258,7 +258,7 @@ h1.example-title .text {
 [data-type="exercise"] {
   [data-type="problem"] {
     p:first-of-type {
-      display: inline;
+      display: inline-block;
       a {
         font-weight: bold;
         margin-right: 0.5em;


### PR DESCRIPTION
https://github.com/openstax/webview/issues/2201
Changed display of `first paragraph` inside `problem` in `exercises` to be `inline-block` in order to get rid of line break before mathjax elements in Safari browser. 