### PR TITLE
#2228 line break in exercises

### DIFF
--- a/src/scripts/modules/media/body/content-baked.less
+++ b/src/scripts/modules/media/body/content-baked.less
@@ -253,7 +253,10 @@ h1.example-title .text {
   .os-solution-container {
     display: inline;
     > :first-child:not(ul):not(ol):not([data-type="note"]):not(.os-figure) {
-      display: inline-block;
+      display: inline;
+      .MathJax {
+        display: inline-block;
+      }
     }
     > ul, > ol, [data-type="note"] {
       margin-top: 0;

--- a/src/scripts/modules/media/body/content-baked.less
+++ b/src/scripts/modules/media/body/content-baked.less
@@ -235,7 +235,7 @@ h1.example-title .text {
   .os-solution-container {
     display: inline;
     > :first-child:not(ul):not(ol):not([data-type="note"]):not(.os-figure) {
-      display: inline;
+      display: inline-block;
     }
     > ul, > ol, [data-type="note"] {
       margin-top: 0;


### PR DESCRIPTION
Issue: https://github.com/openstax/webview/issues/2228

Removed line break in section exercises when paragraph in `os-problem-container` has only mathjax element. Problem occured only on Safari.