### PR TITLE
Remove bullet list from abstract

### DIFF
--- a/src/scripts/modules/media/body/content-baked.less
+++ b/src/scripts/modules/media/body/content-baked.less
@@ -42,6 +42,11 @@ ul, ol {
   }
 }
 
+.os-abstract {
+  list-style-type: none;
+  padding-left: 2rem;
+}
+
 .circled {
   list-style-type: none;
   padding-left: 1rem;


### PR DESCRIPTION
In https://github.com/openstax/cnx-recipes/pull/940 list in abstract in Calculus is changed by recipes to numbered list. That how it looks at this moment:

![image](https://user-images.githubusercontent.com/40228854/55959645-75da2f00-5c6b-11e9-88d0-940c5b6b9ebf.png)

In this PR I removed additional bullet list and I changed the left padding.