### PR TITLE
changed default table styles

### DIFF
--- a/src/scripts/modules/media/body/content-common.less
+++ b/src/scripts/modules/media/body/content-common.less
@@ -422,13 +422,17 @@ table {
     tr > td[data-align="right"]{
       text-align: right;
     }
+    tr > td {
+      padding: 1em;
+      border: 0.1rem solid @table-border-color;
+    }
   }
   tfoot {
     > tr {
       > th,
       > td {
         padding: @table-cell-padding;
-        border-top: 0.1rem solid @table-border-color;
+        border: 0.1rem solid @table-border-color;
         line-height: @line-height-base;
         vertical-align: top;
       }
@@ -438,41 +442,20 @@ table {
   // Bottom align for column headings
   thead > tr > th,
   thead > tr > td {
-    border-bottom: 0.2rem solid @table-border-color;
+    border: 0.2rem solid @table-border-color;
     font-weight: bold;
     text-align: left;
     vertical-align: bottom;
   }
 
-  // Remove top border from thead by default
-  caption + thead,
-  colgroup + thead,
-  thead:first-child {
-    tr:first-child {
-      th, td {
-        border-top: 0;
-      }
-    }
-  }
-
   // Account for multiple tbody instances
   tbody + tbody {
-    border-top: 0.2rem solid @table-border-color;
+    border: 0.2rem solid @table-border-color;
   }
 
   // Nesting
   table {
     background-color: @body-bg;
-  }
-
-  // Zebra striping
-  > tbody {
-    > tr:nth-child(odd) {
-      > td,
-      > th {
-        background-color: @table-bg-accent;
-      }
-    }
   }
 }
 

--- a/src/scripts/modules/media/body/content-common.less
+++ b/src/scripts/modules/media/body/content-common.less
@@ -1,4 +1,4 @@
-@table-cell-padding: 1em;
+@table-cell-padding: 0.5em 1em;
 @base-font: 14px;
 
 // Styles for the contents of a page.
@@ -423,7 +423,7 @@ table {
       text-align: right;
     }
     tr > td {
-      padding: 1em;
+      padding: @table-cell-padding;
       border: 0.1rem solid @table-border-color;
     }
   }


### PR DESCRIPTION
This PR will solve:
https://github.com/openstax/webview/issues/2154
https://github.com/openstax/webview/issues/2183
https://github.com/openstax/webview/issues/2184

It will also affect any other content that is created in tables eg `tables with equations`. 
https://katalyst01.cnx.org/contents/mwjClAV_@8.2:SXjiAlpU@8.2/Key-Equations

@openstaxalina This should look good also for tables with merged cells, paddings in cells also look good. It will be verified by QA.
I was thinking if we should make the `table head` border darker or thicker so it can be distinguished from the table body?