### PR TITLE
Do a hard request for featured book clicks

### DIFF
--- a/src/scripts/modules/featured-books/featured-books-partial.html
+++ b/src/scripts/modules/featured-books/featured-books-partial.html
@@ -1,6 +1,10 @@
 <div class="book">
-  <a href="{{link}}" tabindex="-1"><img src="{{cover}}" width="125" alt="{{title}}" /></a>
-  <h3 id="fb-{{prefix}}-{{id}}-title" class="small-header"><a href="{{link}}">{{title}}</a></h3>
+  <a href="{{link}}" tabindex="-1" data-bypass="true">
+    <img src="{{cover}}" width="125" alt="{{title}}" />
+  </a>
+  <h3 id="fb-{{prefix}}-{{id}}-title" class="small-header">
+    <a href="{{link}}" data-bypass="true">{{title}}</a>
+  </h3>
   <p class="description show-ellipsis">{{{description}}}</p>
   <div class="show-more-less"><a href="" aria-labelledby="fb-{{prefix}}-{{id}}-title" data-l10n-id="featured-books-show-more" class="more">Show More</a><a href="" aria-labelledby="fb-{{prefix}}-{{id}}-title" data-l10n-id="featured-books-show-less" class="less">Show Less</a></div>
 </div>


### PR DESCRIPTION
We are setting the `data-bypass` attribute on the anchor to allow the default
behavior to proceed. This passes the requested link to the browser rather
than having the javascript capture it for internal requesting of new content.

We make the browser do a request of these URLs so that it contacts
the webserver (nginx) to do redirects of REX books (aka all openstax books).

This is associated with openstax/cnx#401