### PR TITLE
#2256 italic elements in note title 

### DIFF
--- a/src/scripts/modules/media/body/content-common.less
+++ b/src/scripts/modules/media/body/content-common.less
@@ -237,6 +237,10 @@ figure[data-orient="vertical"] {
     font-size: 1.5rem;
     letter-spacing: 0.1rem;
     text-transform: uppercase;
+
+    [data-effect="italics"] {
+      text-transform: none;
+    }
   }
   .body(note) {
     padding: 0.5rem 1.5rem;


### PR DESCRIPTION
Issue: https://github.com/openstax/webview/issues/2256.

Italic elements in note titles shouldn't be capitalized.